### PR TITLE
Use an abstract IWebosEglWindow interface to manipulate the EGL window.

### DIFF
--- a/qwebosglcontext.cpp
+++ b/qwebosglcontext.cpp
@@ -111,7 +111,7 @@ QWebOSGLContext::~QWebOSGLContext()
 void QWebOSGLContext::createSurface()
 {
     m_eglSurface = eglCreateWindowSurface(s_eglDisplay, m_eglConfig,
-                                          static_cast<ANativeWindow*>(m_platformWindow),
+                                          m_platformWindow->getEglWindow(),
                                           NULL);
 
     if (m_eglSurface == EGL_NO_SURFACE) {

--- a/qweboswindow.h
+++ b/qweboswindow.h
@@ -24,27 +24,29 @@
 
 QT_BEGIN_NAMESPACE
 
-#include <EGL/eglhybris.h>
-
-#include <OffscreenNativeWindow.h>
+#include <EGL/egl.h>
 
 typedef WId QWebOSWindowId;
 
 class QWebOSScreen;
 class QWebOSGLContext;
+class IWebosEglWindow;
 
-class QWebOSWindow : public QPlatformWindow,
-                     public OffscreenNativeWindow
+class QWebOSWindow : public QPlatformWindow
 {
 public:
     QWebOSWindow(QWidget *w, QWebOSScreen *screen);
 
     virtual void setGeometry(const QRect &);
 
+    void resize(int iNewWidth, int iNewHeight);
+
     WId winId() const;
     virtual void setWinId(WId winId);
 
     QPlatformGLContext *glContext() const;
+
+    EGLNativeWindowType getEglWindow();
 
     void createGLContext();
 
@@ -55,6 +57,7 @@ private:
     QWebOSScreen *m_screen;
     QWebOSGLContext *m_glcontext;
     WId m_winid;
+    IWebosEglWindow *m_webosEglWindow;
 };
 
 QT_END_NAMESPACE

--- a/webos.pro
+++ b/webos.pro
@@ -48,7 +48,7 @@ INCLUDEPATH += $$QT_BUILD_TREE/include/QtGui
 INCLUDEPATH += $$QT_BUILD_TREE/include/QtCore
 SOURCES += $$QT_SOURCE_TREE/src/gui/text/qfontengine_ft.cpp
 
-QMAKE_CXXFLAGS += -fno-rtti -fno-exceptions
+QMAKE_CXXFLAGS += -fno-exceptions
 
 QMAKE_CLEAN += libqwebos.so
 


### PR DESCRIPTION
This interface is defined in libwebos-gui, so the dependancy to libhybris itself is not needed anymore.

Nota Bene: this PR belongs to the following set of PR for webOS-ports: libwebos-gui, qt-webos-plugin, webappmanager, luna-sysmgr and meta-webos-ports.
